### PR TITLE
Bugfix/restore old template context

### DIFF
--- a/src/EventListener/RenderingForwarder.php
+++ b/src/EventListener/RenderingForwarder.php
@@ -101,6 +101,10 @@ class RenderingForwarder
         $template = $data[self::TWIG_TEMPLATE] ?? null;
         $context = $data[self::TEMPLATE_CONTEXT] ?? null;
 
+        // restore old template context, so that legacy modules are happy
+        // (e.g. ModuleNavigation is checking for Template->items)
+        $contaoTemplate->setData($context);
+
         if (null === $template) {
             throw new \InvalidArgumentException("The template's context must contain a value for '".self::TWIG_TEMPLATE."'");
         }


### PR DESCRIPTION
This fixes modules like `ModuleNavigation` and co not displaying any content when overwriting their templates.