### PR TITLE
Fix fe_* templates not setting cache headers

### DIFF
--- a/src/EventListener/RenderingForwarder.php
+++ b/src/EventListener/RenderingForwarder.php
@@ -21,6 +21,7 @@ class RenderingForwarder
 {
     private const TWIG_TEMPLATE = 'twig_template';
     private const TEMPLATE_CONTEXT = 'context';
+    private const CONTAO_TEMPLATE = 'contao_template';
 
     private Environment $twig;
     private TemplateLocator $templateLocator;
@@ -79,7 +80,8 @@ class RenderingForwarder
      */
     public function delegateRendering(Template $contaoTemplate): void
     {
-        $template = $this->templates[$contaoTemplate->getName()] ?? null;
+        $originalName = $contaoTemplate->getName();
+        $template = $this->templates[$originalName] ?? null;
 
         if (null === $template) {
             return;
@@ -91,6 +93,7 @@ class RenderingForwarder
         $contaoTemplate->setData([
             self::TWIG_TEMPLATE => $template,
             self::TEMPLATE_CONTEXT => $contaoTemplate->getData(),
+            self::CONTAO_TEMPLATE => $originalName,
         ]);
     }
 
@@ -100,6 +103,11 @@ class RenderingForwarder
 
         $template = $data[self::TWIG_TEMPLATE] ?? null;
         $context = $data[self::TEMPLATE_CONTEXT] ?? null;
+        $originalName = $data[self::CONTAO_TEMPLATE] ?? '';
+
+        // restore old template name, so that FrontendTemplate sets the right
+        // cache headers in case of fe_* templates
+        $contaoTemplate->setName($originalName);
 
         // restore old template context, so that legacy modules are happy
         // (e.g. ModuleNavigation is checking for Template->items)

--- a/tests/EventListener/RenderingForwarderTest.php
+++ b/tests/EventListener/RenderingForwarderTest.php
@@ -85,6 +85,7 @@ class RenderingForwarderTest extends TestCase
             ->with([
                 'twig_template' => 'sub/bar.html.twig',
                 'context' => ['a' => 123],
+                'contao_template' => 'bar',
             ]);
 
         $renderingForwarder->delegateRendering($template);


### PR DESCRIPTION
This PR restores the original template names after rendering. Otherwise rendering a proxy for `fe_page` / `fe_*` would not produce the same cache headers. 

see https://github.com/contao/contao/blob/712de2476dc6100cad1876da1f22b809f7558d5c/core-bundle/src/Resources/contao/classes/FrontendTemplate.php#L87-L90