### PR TITLE
Add RenderTemplateEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,34 @@
    That's it. Your new template is now rendered instead. It has the same context
    as the existing Contao one would have (`Template->getData()`). :sparkles:
 
+#### Render event
+The system dispatches an event directly *before* a twig template gets rendered. It 
+allows altering the template context or even the actual template that is going to be 
+rendered:
+
+```yml
+# config/services.yaml
+services:
+    App\EventListener\RenderTemplateListener:
+        tags:
+            - { name: kernel.event_listener, event: 'Mvo\ContaoTwig\Event\RenderTemplateEvent' }
+```
+
+```php
+// App\EventListener\RenderTemplateListener
+
+public function __invoke(\Mvo\ContaoTwig\Event\RenderTemplateEvent  $event): void {
+    $context = $event->getContext(); // the template's context
+    $template = $event->getTemplate(); // the template's name
+    $contaoTemplate = $event->getContaoTemplate(); // the original Contao template
+    
+    // …
+    
+    $event->setTemplate('another-template.html.twig');
+    $event->setContext(array_merge($context, ['foo' => 'bar']));
+}
+```
+
 #### Caveats
 As Contao uses input encoding, you'll need to deal for already encoded variables
 yourself by adding the `|raw` filter. Use with caution and be sure you know what

--- a/src/Event/RenderTemplateEvent.php
+++ b/src/Event/RenderTemplateEvent.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @author  Moritz Vondano
+ * @license MIT
+ */
+
+namespace Mvo\ContaoTwig\Event;
+
+use Contao\Template;
+
+class RenderTemplateEvent
+{
+    private Template $contaoTemplate;
+
+    private string $template;
+
+    private array $context;
+
+    public function __construct(Template $contaoTemplate, string $template, array $context)
+    {
+        $this->contaoTemplate = $contaoTemplate;
+        $this->template = $template;
+        $this->context = $context;
+    }
+
+    public function getContaoTemplate(): Template
+    {
+        return $this->contaoTemplate;
+    }
+
+    public function getTemplate(): string
+    {
+        return $this->template;
+    }
+
+    public function setTemplate(string $template): void
+    {
+        $this->template = $template;
+    }
+
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    public function setContext(array $context): void
+    {
+        $this->context = $context;
+    }
+}


### PR DESCRIPTION
This PR adds an event that gets dispatched before the replacement twig template gets rendered. 

It basically allows altering the template + context before it gets rendered, which should e.g. be handy in case you want to wrap all data into a class that is considered "safe" (like in this proposal https://github.com/contao/contao/pull/2612).

/cc @dmolineus, @richardhj